### PR TITLE
Fixed:timer_settime failes on 32bit linux

### DIFF
--- a/tlmu.c
+++ b/tlmu.c
@@ -49,6 +49,7 @@
 static timer_t tlmu_hosttimer;
 pthread_mutex_t timer_mutex = PTHREAD_MUTEX_INITIALIZER;
 static struct tlmu_timer *timers = NULL;
+static const int64_t default_next_timer_check_ns = 1000000000LL; //1sec
 
 static void tlmu_hosttimer_start(int64_t delta_ns)
 {
@@ -82,6 +83,10 @@ static int64_t tlmu_timers_run(int64_t current_ns)
 		}
 		t = t->next;
 	}
+	if(next_deadline == INT64_MAX) { //no timers found
+		next_deadline = current_ns + default_next_timer_check_ns;
+	}
+
 	return next_deadline;
 }
 


### PR DESCRIPTION
Hi Edgar,
I hit an error on 32bit linux.
Calling timer_settime() in tlmu_hosttimer_start(int64_t) sometimes emits an error.
It is because timeout.it_interval.tv_sec is negative value.
time_t is 32bit signed integer on 32bit platform.

When no timers are found in tlmu_timers_run(),  it returns INT64_MAX.
And it cause overflow in timer_settime() and tv_sec is then negative.
I changed tlmu_timers_run() to set "next_deadline" 1sec future if notimers are found.
I am not sure 1sec(default_next_timer_check_ns) is optimal or not.
Please fix the value if you find better value.

BTW the previous pull request looks still open on github.com.

Regards, Yutestu.
